### PR TITLE
add constructor(Iterable<string>)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fast ternary string set
 
-A fast string set based on ternary search trees, with both exact and approximate membership tests.
+A fast, space-efficient, serializable string set based on ternary search trees, with both exact and approximate membership tests.
 
 Features:
 
@@ -30,7 +30,7 @@ npm install fast-ternary-string-set
 
 Or, if using `yarn`, `yarn add fast-ternary-string-set`.
 
-Alternatively, to use it without Node.js, copy the main source file (`src/index.ts`) into any TypeScript project, then `import` the copied file into your code.
+Alternatively, to use it without Node.js, copy the main source file (`src/index.ts`) into any TypeScript project, then `import` the copied file into your code. (You will probably want to rename the file to something appropriate, such as `ternary-string-set.ts`.)
 
 ## Examples of use
 
@@ -59,6 +59,17 @@ set.has("cat");
 // => false
 set.has(123.456);
 // => false (any non-string returns false)
+```
+
+Create a new string set from an existing set or other `Iterable<string>`:
+
+```js
+// otherSet could be any Iterable<string>, such as a string array
+// or even another TernaryStringSet
+let otherSet = new Set(["fish", "hippo"]);
+let set = new TernaryStringSet(otherSet);
+set.has("hippo");
+// => true
 ```
 
 Add an entire array of string elements:
@@ -125,7 +136,7 @@ JavaScript `Set` objects guarantee that they iterate over elements in the order 
 
 Adding strings to a ternary tree in sorted order produces a worst-case tree structure. This can be avoided by adding
 sorted strings using the `addAll` method, which produces an optimal tree structure given a sorted input array.
-Alternatively, the `balance` method can be called to rebuild the tree with optimal structure, but this is expensive.
+Alternatively, the `balance` method can be called to rebuild the tree with optimal structure, but this can be expensive.
 
 After deleting a large number of strings, future search performance may be improved by calling `balance`.
 
@@ -153,5 +164,13 @@ The included `tsconfig.json` targets ES2015 (ES6). To target old JavaScript engi
 The project includes an extensive suite of tests under `src/tests`. To run all tests:
 
 ```bash
+npm test
+```
+
+Before submitting a pull request, format, lint, and run all tests:
+
+```bash
+npm run format
+npm run lint
 npm test
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,9 +47,35 @@ export class TernaryStringSet implements Set<string>, Iterable<string> {
   /** Tracks set size. */
   #size: number;
 
-  /** Creates a new, empty set. */
-  constructor() {
+  /**
+   * Creates a new set. The set will be empty unless the optional iterable `source` object
+   * is specified. If a `source` is provided, all of its elements will be added to the new set.
+   * If `source` contains any element that would cause `add()` to throw an error, the constructor
+   * will also throw an error for that element.
+   *
+   * **Note:** Since strings are iterable, passing a string to the constructor will create
+   * a new set containing one string for each unique code point in the source string, and not
+   * a singleton set containing just the source string as you might expect.
+   *
+   * @param source An optional iterable object whose strings will be added to the new set.
+   */
+  constructor(source?: Iterable<string>) {
     this.clear();
+
+    if (source != null) {
+      if (typeof source[Symbol.iterator] !== "function") {
+        throw new TypeError("source object is not iterable");
+      }
+      if (source instanceof TernaryStringSet) {
+        this.#tree = source.#tree.slice();
+        this.#hasEmpty = source.#hasEmpty;
+        this.#size = source.#size;
+      } else if (Array.isArray(source)) {
+        this.addAll(source);
+      } else {
+        this.addAll(Array.from(source));
+      }
+    }
   }
 
   /**

--- a/src/tests/ctor-tests.ts
+++ b/src/tests/ctor-tests.ts
@@ -1,0 +1,96 @@
+import { TernaryStringSet } from "../index";
+
+/** Simple set equality test that does not rely on `equals()`. */
+function sameSet(lhs: TernaryStringSet, rhs: TernaryStringSet) {
+  if (lhs.size !== rhs.size) return false;
+  let eq = true;
+  const a = Array.from(lhs),
+    b = Array.from(rhs);
+  for (let i = 0; i < a.length; ++i) {
+    if (a[i] !== b[i]) {
+      eq = false;
+      break;
+    }
+  }
+  return eq;
+}
+
+test("No-arg constructor yields empty set", () => {
+  expect(new TernaryStringSet().size).toBe(0);
+});
+
+test("Non-iterable constructor argument throws", () => {
+  expect(
+    () => new TernaryStringSet(1 as unknown as Iterable<string>),
+  ).toThrow();
+  expect(
+    () => new TernaryStringSet({} as unknown as Iterable<string>),
+  ).toThrow();
+});
+
+test("Empty iterable constructor yields empty set", () => {
+  expect(new TernaryStringSet([]).size).toBe(0);
+  expect(new TernaryStringSet(new Set()).size).toBe(0);
+  expect(new TernaryStringSet("").size).toBe(0);
+});
+
+test("TernaryStringTree constructor argument yields equivalent set", () => {
+  const t1 = new TernaryStringSet();
+  expect(sameSet(t1, new TernaryStringSet(t1))).toBeTruthy();
+  t1.add("");
+  expect(sameSet(t1, new TernaryStringSet(t1))).toBeTruthy();
+  t1.addAll(["ankle", "spoon", "xenomorph"]);
+  expect(sameSet(t1, new TernaryStringSet(t1))).toBeTruthy();
+  t1.delete("");
+  expect(sameSet(t1, new TernaryStringSet(t1))).toBeTruthy();
+  t1.delete("spoon");
+  expect(sameSet(t1, new TernaryStringSet(t1))).toBeTruthy();
+  t1.delete("ankle");
+  expect(sameSet(t1, new TernaryStringSet(t1))).toBeTruthy();
+  t1.delete("xenomorph");
+  expect(sameSet(t1, new TernaryStringSet(t1))).toBeTruthy();
+});
+
+test("Array constructor argument yields equivalent set", () => {
+  const addAll = (a: string[]) => {
+    const set = new TernaryStringSet();
+    set.addAll(a);
+    return set;
+  };
+  let a = ["axolotl"];
+  expect(sameSet(addAll(a), new TernaryStringSet(a))).toBeTruthy();
+  a = ["tardigrade", "zebu"];
+  expect(sameSet(addAll(a), new TernaryStringSet(a))).toBeTruthy();
+  a = ["", "dog", "cat", "shoebill"];
+  expect(sameSet(addAll(a), new TernaryStringSet(a))).toBeTruthy();
+  a = ["dog", "cat", "shoebill"];
+  expect(sameSet(addAll(a), new TernaryStringSet(a))).toBeTruthy();
+});
+
+class GenericIterator implements Iterator<string> {
+  i = 1;
+  next(): IteratorResult<string> {
+    return this.i < 5
+      ? { done: false, value: String(this.i++) }
+      : { done: true, value: undefined };
+  }
+}
+
+test("Generic iterable yields equivalent set", () => {
+  const itTree = (it: Iterable<string>) => {
+    const set = new TernaryStringSet();
+    set.addAll(Array.from(it));
+    return set;
+  };
+
+  let it: Iterable<string> = new Set();
+  expect(sameSet(itTree(it), new TernaryStringSet(it))).toBeTruthy();
+  (it as Set<string>).add("quetzal").add("umbrellabird");
+  expect(sameSet(itTree(it), new TernaryStringSet(it))).toBeTruthy();
+  it = "hello, world!";
+  expect(sameSet(itTree(it), new TernaryStringSet(it))).toBeTruthy();
+  it = {
+    [Symbol.iterator]: () => new GenericIterator(),
+  };
+  expect(sameSet(itTree(it), new TernaryStringSet(it))).toBeTruthy();
+});


### PR DESCRIPTION
To match the behavior of `Set<string>` the constructor should accept an `Iterable<string>` parameter and add the iterator's elements to the new set.